### PR TITLE
feat: add GolangGoModMerge for merging go.mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# stencil-languages
+
+Stencil module for generating and interacting with various programming
+language specific files.
+
+## Currently Supported
+
+### Golang
+
+* Merging `go.mod` files with `GolangGoModMerge`. Example usage:
+
+```go
+// go.mod.tpl
+{{- define "go.mod" }}
+module github.com/rgst-io/my-golang-module
+
+go 1.18
+
+// All Go repos should have min module version and this module.
+require github.com/jaredallard/cmdexec v1.2.0
+{{- end }}
+
+// We're generating go.mod in this file, so we shouldn't output
+// a file  from this template.
+{{ file.Skip }}
+
+// Render the go mod file, use it if we don't have an existing go.mod
+{{ $newGoMod := (stencil.ApplyTemplate "go.mod") }}
+{{ $goModContents := $newGoMod }}
+{{ file.Create "go.mod" 0600 now }}
+
+// If the go.mod already exists, merge it with the generated one
+// then write it to disk.
+{{- if stencil.Exists "go.mod" }}
+{{ $goModContents = (extensions.Call "github.com/rgst-io/stencil-languages.GolangMergeGoMod" (stencil.ReadFile "go.mod") $newGoMod) }}
+{{- end }}
+
+// Write out the go.mod
+{{ file.SetContents $goModContents }}
+```
+
+## License
+
+GPL-3.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ language specific files.
 
 ### Golang
 
-* Merging `go.mod` files with `GolangGoModMerge`. Example usage:
+* Merging `go.mod` files with `GolangMergeGoMod`. Example usage:
 
 ```go
 // go.mod.tpl

--- a/cmd/plugin/plugin.go
+++ b/cmd/plugin/plugin.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2024 stencil-languages contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0
+
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+
+	"github.com/rgst-io/stencil-languages/internal/plugin"
+	"go.rgst.io/stencil/pkg/extensions/apiv1"
+	"go.rgst.io/stencil/pkg/slogext"
+)
+
+// main starts the stencil-languages plugin
+func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	log := slogext.New()
+
+	err := apiv1.NewExtensionImplementation(plugin.New(ctx), log)
+	if err != nil {
+		log.WithError(err).Error("failed to create extension")
+	}
+
+	// close the context
+	cancel()
+
+	if err != nil {
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.23
 
 require (
 	github.com/blang/semver/v4 v4.0.0
-	github.com/google/go-cmp v0.6.0
 	go.rgst.io/stencil v0.11.0
 	golang.org/x/mod v0.21.0
 	gotest.tools/v3 v3.5.1
@@ -18,6 +17,7 @@ require (
 	github.com/fatih/color v1.17.0 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-plugin v1.6.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/internal/languages/golang/golang.go
+++ b/internal/languages/golang/golang.go
@@ -1,0 +1,140 @@
+// Copyright (C) 2024 stencil-languages contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0
+
+// Package golang implements Golang specific helpers for stencil
+// templates generating Golang code.
+package golang
+
+import (
+	"fmt"
+
+	"github.com/blang/semver/v4"
+	"golang.org/x/mod/modfile"
+)
+
+// MergeGoMod merges two go.mod files together. This function operates
+// differently than a standard merge would. It is designed to
+// conditionally merge an existing go.mod file with a templated go.mod.
+//
+// ## Behaviour
+//
+// Noted as the "left" and "right" go.mod files (first and second values
+// provided). They are merged with the following rules:
+//   - Versions from the right go.mod file will be used if the version
+//     is greater than the version in the left go.mod file or the module
+//     is not present in the left go.mod file. If a module in the left
+//     go.mod is newer than the module in the right go.mod, the left
+//     version will be used.
+//   - Replacements from the right go.mod file will be kept if they are
+//     not in the left go.mod file. If a replacement in the right go.mod
+//     has the same path as a replacement in the left go.mod, the left
+//     replacement will be kept. Replacements existing in the left go.mod
+//     but not in the right go.mod will be kept.
+//   - The go and toolchain statements from the right go.mod file will
+//     always be used over the left go.mod file.
+//
+// This is heavily based on getoutreach/stencil-golang, which is
+// licensed under the Apache-2.0 license. Link to the original as it
+// appeared in the stencil-golang repository:
+// https://github.com/getoutreach/stencil-golang/blob/993a3fc484e5631dd9e7004bdd304cbacac7cccd/internal/plugin/merge.go
+func MergeGoMod(leftB, rightB []byte) ([]byte, error) {
+	leftMod, err := modfile.Parse("go.left.mod", leftB, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse left go.mod: %w", err)
+	}
+
+	// Build a map of the left hand module paths to their version.
+	leftMods := make(map[string]semver.Version)
+	for _, mod := range leftMod.Require {
+		v, err := semver.ParseTolerant(mod.Mod.Version)
+		if err != nil {
+			continue
+		}
+
+		leftMods[mod.Mod.Path] = v
+	}
+
+	// Build a map of the replaces in the left hand go.mod.
+	leftReplaces := make(map[string]*modfile.Replace)
+	for _, repl := range leftMod.Replace {
+		leftReplaces[repl.Old.Path] = repl
+	}
+
+	rightMod, err := modfile.Parse("go.right.mod", rightB, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse right go.mod: %w", err)
+	}
+
+	// Change the left hand module versions if the right hand versions
+	// are greater than the left hand ones.
+	for _, req := range rightMod.Require {
+		rv, err := semver.ParseTolerant(req.Mod.Version)
+		if err != nil {
+			// Invalid, skip. Go would be yelling about this anyways.
+			continue
+		}
+
+		// Check if it exists in the left hand go.mod.
+		if lv, ok := leftMods[req.Mod.Path]; ok {
+			// If the right version is less than the left, skip. We don't want
+			// to downgrade.
+			if rv.LT(lv) {
+				continue
+			}
+		}
+
+		// The right hand version is either greater than left or isn't
+		// present in the left go.mod. Add it to the left hand go.mod.
+		if err := leftMod.AddRequire(req.Mod.Path, req.Mod.Version); err != nil {
+			return nil, fmt.Errorf("failed to add/update dependency '%s': %w", req.Mod.Path, err)
+		}
+	}
+
+	// Add any modules that exist in the right go.mod, but not in the
+	// left.
+	for _, repl := range rightMod.Replace {
+		// If the left go.mod already has a replacement for this module,
+		// don't add a replacement for it from the right.
+		if _, ok := leftReplaces[repl.Old.Path]; ok {
+			continue
+		}
+
+		if err := leftMod.AddReplace(repl.Old.Path, repl.Old.Version, repl.New.Path, repl.New.Version); err != nil {
+			return nil, fmt.Errorf("failed to add replacement '%s': %w", repl.Old.Path, err)
+		}
+	}
+
+	// Always use the go version from the right hand go.mod if present.
+	if rightMod.Go != nil && rightMod.Go.Version != "" {
+		if err := leftMod.AddGoStmt(rightMod.Go.Version); err != nil {
+			return nil, fmt.Errorf("failed to set go version: %w", err)
+		}
+	}
+
+	// Always use the toolchain from the right hand go.mod if it is set.
+	if rightMod.Toolchain != nil && rightMod.Toolchain.Name != "" {
+		if err := leftMod.AddToolchainStmt(rightMod.Toolchain.Name); err != nil {
+			return nil, fmt.Errorf("failed to set toolchain: %w", err)
+		}
+	}
+
+	newBytes, err := leftMod.Format()
+	if err != nil {
+		return nil, fmt.Errorf("failed to format go.mod: %w", err)
+	}
+	return newBytes, nil
+}

--- a/internal/languages/golang/golang_test.go
+++ b/internal/languages/golang/golang_test.go
@@ -1,0 +1,115 @@
+// Copyright (C) 2024 stencil-languages contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0
+
+package golang_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rgst-io/stencil-languages/internal/languages/golang"
+	"gotest.tools/v3/assert"
+)
+
+func TestMergeGoMod(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    string
+		wantErr string
+	}{
+		{
+			name: "should do nothing when both are empty",
+			args: []string{"", ""},
+		},
+		{
+			name: "should replace left when empty",
+			args: []string{"", "go 1.16"},
+			want: "go 1.16",
+		},
+		{
+			name: "should use version from right if newer than left",
+			args: []string{"require foo v1.0.0", "require foo v1.1.0"},
+			want: "require foo v1.1.0",
+		},
+		{
+			name: "should add version from right if not in left",
+			args: []string{"require foo v1.0.0", "require bar v1.1.0"},
+			want: strings.Join([]string{
+				"require (",
+				"	foo v1.0.0",
+				"	bar v1.1.0",
+				")",
+			}, "\n"),
+		},
+		{
+			name: "should keep version from left if newer than right",
+			args: []string{"require foo v1.1.0", "require foo v1.0.0"},
+			want: "require foo v1.1.0",
+		},
+		{
+			name: "should keep replacements from left if not in right",
+			args: []string{"replace foo => bar v1.0.0", ""},
+			want: "replace foo => bar v1.0.0",
+		},
+		{
+			name: "should add replacements from right if not in left",
+			args: []string{"", "replace foo => bar v1.0.0"},
+			want: "replace foo => bar v1.0.0",
+		},
+		{
+			name: "should add go statement from right if present",
+			args: []string{"", "go 1.16"},
+			want: "go 1.16",
+		},
+		{
+			name: "should replace go statement from left if present",
+			args: []string{"go 1.15", "go 1.16"},
+			want: "go 1.16",
+		},
+		{
+			name: "should add toolchain statement from right if present",
+			args: []string{"", "toolchain go1.23.2"},
+			want: "toolchain go1.23.2",
+		},
+		{
+			name: "should replace toolchain statement from left if present",
+			args: []string{"toolchain go1.23.1", "toolchain go1.23.2"},
+			want: "toolchain go1.23.2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Assert(t, len(tt.args) == 2, "expected exactly 2 arguments")
+
+			gotB, err := golang.MergeGoMod([]byte(tt.args[0]), []byte(tt.args[1]))
+			got := string(gotB)
+			if got != "" && strings.HasSuffix(got, "\n") {
+				// Ensure we have no trailing newline for testing.
+				got = got[:len(got)-1]
+			}
+			if tt.wantErr != "" {
+				assert.Assert(t, err != nil, "expected an error")
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.DeepEqual(t, got, tt.want)
+		})
+	}
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -1,0 +1,82 @@
+// Copyright (C) 2024 stencil-languages contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0
+
+// Package plugin implements the entrypoint for the stencil-languages
+// plugin.
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rgst-io/stencil-languages/internal/languages/golang"
+	"go.rgst.io/stencil/pkg/extensions/apiv1"
+)
+
+// _ ensures that StencilGolangPlugin implements the [apiv1.Implementation] interface.
+var _ apiv1.Implementation = &Instance{}
+
+// Instance contains a [apiv1.Implementation] satisfying plugin.
+type Instance struct {
+	ctx context.Context
+}
+
+// New creates a new [Instance].
+func New(ctx context.Context) *Instance {
+	return &Instance{ctx: ctx}
+}
+
+// GetConfig returns a [apiv1.Config] for the [Instance].
+func (*Instance) GetConfig() (*apiv1.Config, error) {
+	return &apiv1.Config{}, nil
+}
+
+// GetTemplateFunctions returns the [apiv1.TemplateFunction]s for the
+// [Instance].
+func (*Instance) GetTemplateFunctions() ([]*apiv1.TemplateFunction, error) {
+	return []*apiv1.TemplateFunction{
+		// GolangMergeGoMod calls [golang.MergeGoMod].
+		{
+			Name:              "GolangMergeGoMod",
+			NumberOfArguments: 2,
+		},
+	}, nil
+}
+
+// ExecuteTemplateFunction executes a template function for the [Instance].
+func (i *Instance) ExecuteTemplateFunction(exec *apiv1.TemplateFunctionExec) (any, error) {
+	switch exec.Name { //nolint:gocritic // Why: Will add more cases soon.
+	case "GolangMergeGoMod":
+		// Safe because of the NumberOfArguments check.
+		left, ok := exec.Arguments[0].(string)
+		if !ok {
+			return nil, fmt.Errorf("argument 0 invalid, expected string got %T", exec.Arguments[0])
+		}
+
+		right, ok := exec.Arguments[1].(string)
+		if !ok {
+			return nil, fmt.Errorf("argument 1 invalid, expected string got %T", exec.Arguments[1])
+		}
+
+		resp, err := golang.MergeGoMod([]byte(left), []byte(right))
+		if err != nil {
+			return "", err
+		}
+		return string(resp), nil
+	}
+	return nil, fmt.Errorf("unknown template function: %s", exec.Name)
+}

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2024 stencil-languages contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0
+
+package plugin_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rgst-io/stencil-languages/internal/plugin"
+	"go.rgst.io/stencil/pkg/extensions/apiv1"
+	"gotest.tools/v3/assert"
+)
+
+// TestGolangGoModMerge ensures that we can call the GolangGoModMerge
+// template function.
+func TestGolangGoModMerge(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// TODO(jaredallard): There's no package exported by stencil for
+	// testing the over the wire functionality. Best we can do is mimic
+	// stencil by using [apiv1.Implementation].
+	var impl apiv1.Implementation = plugin.New(ctx)
+
+	resp, err := impl.ExecuteTemplateFunction(&apiv1.TemplateFunctionExec{
+		Name:      "GolangMergeGoMod",
+		Arguments: []any{"go 1.16", "go 1.17"},
+	})
+	assert.NilError(t, err, "failed to execute template function")
+	assert.Equal(t, resp, "go 1.17\n", "expected go1.17")
+}

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -26,9 +26,9 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-// TestGolangGoModMerge ensures that we can call the GolangGoModMerge
+// TestGolangMergeGoMod ensures that we can call the GolangMergeGoMod
 // template function.
-func TestGolangGoModMerge(t *testing.T) {
+func TestGolangMergeGoMod(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 


### PR DESCRIPTION
Based on the original implementation added in
getoutreach/stencil-golang[^1], this adds support for merging go.mod
files in the context of a "user" and templated version.

Included is full testing of the documented behaviours in the function
comment.

[^1]: https://github.com/getoutreach/stencil-golang/blob/993a3fc484e5631dd9e7004bdd304cbacac7cccd/internal/plugin/merge.go